### PR TITLE
[FIX] Kafka 역직렬화 오류 해결을 위해 Admin WAS와 DTO 패키지 구조 및 클래스명 통일

### DIFF
--- a/wooreadmin/src/main/java/com/piehouse/wooreadmin/dividend/service/DividendServiceImpl.java
+++ b/wooreadmin/src/main/java/com/piehouse/wooreadmin/dividend/service/DividendServiceImpl.java
@@ -3,7 +3,7 @@ package com.piehouse.wooreadmin.dividend.service;
 import com.piehouse.wooreadmin.estate.entity.Estate;
 import com.piehouse.wooreadmin.estate.entity.EstateStatus;
 import com.piehouse.wooreadmin.estate.repository.EstateRepository;
-import com.piehouse.wooreadmin.global.kafka.dto.DividendCompleteMessage;
+import com.piehouse.woorepie.global.kafka.dto.DividendAcceptEvent;
 import com.piehouse.wooreadmin.global.kafka.service.KafkaProducerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ public class DividendServiceImpl implements DividendService {
     @Override
     public boolean approveDividend(Long estateId, Integer dividend) {
         try{
-            DividendCompleteMessage message = DividendCompleteMessage.builder()
+            DividendAcceptEvent message = DividendAcceptEvent.builder()
                     .estate_id(estateId)
                     .dividend(dividend)
                     .build();

--- a/wooreadmin/src/main/java/com/piehouse/wooreadmin/global/kafka/service/KafkaProducerService.java
+++ b/wooreadmin/src/main/java/com/piehouse/wooreadmin/global/kafka/service/KafkaProducerService.java
@@ -1,13 +1,12 @@
 package com.piehouse.wooreadmin.global.kafka.service;
 
-import com.piehouse.wooreadmin.global.kafka.dto.DividendCompleteMessage;
-import com.piehouse.wooreadmin.global.kafka.dto.CompleteEvent;
+import com.piehouse.woorepie.global.kafka.dto.DividendAcceptEvent;
 
 public interface KafkaProducerService {
 
     void sendSaleCompleteEvent(Long estateId);
 
-    void sendDividendCompleteEvent(DividendCompleteMessage event);
+    void sendDividendCompleteEvent(DividendAcceptEvent event);
 
     void sendSubscriptionCompleteEvent(Long estateId);
 

--- a/wooreadmin/src/main/java/com/piehouse/wooreadmin/global/kafka/service/implement/KafkaProducerServiceImpl.java
+++ b/wooreadmin/src/main/java/com/piehouse/wooreadmin/global/kafka/service/implement/KafkaProducerServiceImpl.java
@@ -1,7 +1,7 @@
 package com.piehouse.wooreadmin.global.kafka.service.implement;
 
-import com.piehouse.wooreadmin.global.kafka.dto.DividendCompleteMessage;
-import com.piehouse.wooreadmin.global.kafka.dto.CompleteEvent;
+import com.piehouse.woorepie.global.kafka.dto.DividendAcceptEvent;
+import com.piehouse.woorepie.global.kafka.dto.CompleteEvent;
 import com.piehouse.wooreadmin.global.kafka.service.KafkaProducerService;
 import com.piehouse.wooreadmin.global.kafka.util.KafkaRetryUtil;
 import com.piehouse.wooreadmin.subscription.repository.SubscriptionRepository;
@@ -35,7 +35,7 @@ public class KafkaProducerServiceImpl implements KafkaProducerService {
     }
 
     @Override
-    public void sendDividendCompleteEvent(DividendCompleteMessage event) {
+    public void sendDividendCompleteEvent(DividendAcceptEvent event) {
         send(DIVIDEND_RESPONSE_TOPIC, event);
     }
 

--- a/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/CompleteEvent.java
+++ b/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/CompleteEvent.java
@@ -1,4 +1,4 @@
-package com.piehouse.wooreadmin.global.kafka.dto;
+package com.piehouse.woorepie.global.kafka.dto;
 
 
 import lombok.AllArgsConstructor;

--- a/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/DividendAcceptEvent.java
+++ b/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/DividendAcceptEvent.java
@@ -1,4 +1,4 @@
-package com.piehouse.wooreadmin.global.kafka.dto;
+package com.piehouse.woorepie.global.kafka.dto;
 
 
 import lombok.AllArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class DividendCompleteMessage {
+public class DividendAcceptEvent {
 
     private Long estate_id;
 

--- a/wooreadmin/src/main/resources/application.properties
+++ b/wooreadmin/src/main/resources/application.properties
@@ -37,7 +37,7 @@ spring.kafka.bootstrap-servers=${KAFKA_IP}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 spring.kafka.producer.properties.spring.json.trusted.packages=com.piehouse.woorepie.global.kafka.dto
-spring.kafka.producer.properties.spring.json.add.type.headers=false
+spring.kafka.producer.properties.spring.json.add.type.headers=true
 # Consumer
 spring.kafka.consumer.group-id=${KAFKA_CONSUMER_GROUP}
 spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
## ✨ 작업 개요
- Admin WAS와 일반 WAS 간 Kafka 메시지 역직렬화 오류 해결을 위해 DTO 클래스명 및 패키지명을 통일하고, type header 설정을 적용했습니다.

## ✅ 작업 목록
- [x] spring.kafka.producer.properties.spring.json.add.type.headers=true 설정
- [x] Kafka DTO 패키지명을 `com.piehouse.woorepie.global.kafka.dto`로 통일
- [x] DTO 클래스명 및 필드 구조 일치화

## 📎 관련 이슈
- #16 