### PR TITLE
[FIX] Kafka 배당금 승인 이벤트 estate_id 변수명 불일치 수정

### DIFF
--- a/wooreadmin/src/main/java/com/piehouse/wooreadmin/dividend/service/DividendServiceImpl.java
+++ b/wooreadmin/src/main/java/com/piehouse/wooreadmin/dividend/service/DividendServiceImpl.java
@@ -32,7 +32,7 @@ public class DividendServiceImpl implements DividendService {
     public boolean approveDividend(Long estateId, Integer dividend) {
         try{
             DividendAcceptEvent message = DividendAcceptEvent.builder()
-                    .estate_id(estateId)
+                    .estateId(estateId)
                     .dividend(dividend)
                     .build();
             kafkaProducerService.sendDividendCompleteEvent(message);

--- a/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/DividendAcceptEvent.java
+++ b/wooreadmin/src/main/java/com/piehouse/woorepie/global/kafka/dto/DividendAcceptEvent.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DividendAcceptEvent {
 
-    private Long estate_id;
+    private Long estateId;
 
     private Integer dividend;
 


### PR DESCRIPTION
## ✨ 작업 개요
배당금 승인 이벤트(DTO)에서 변수명이 WAS와 Admin WAS 간에 달라 Kafka 리스너가 정상 동작하지 않던 문제 해결

## ✅ 작업 목록
- [x] 배당금 승인 이벤트 DTO의 estate_id → estateId로 변수명 통일

## 📎 관련 이슈
- #16 